### PR TITLE
Add gunicorn to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,7 @@ fonttools==4.55.8
 frappe==0.0.1
 frozenlist==1.5.0
 fsspec==2025.2.0
+gunicorn==23.0.0
 google-ai-generativelanguage==0.6.6
 google-api-core==2.24.1
 google-api-python-client==2.162.0


### PR DESCRIPTION
Include gunicorn in the requirements to facilitate running the application with a WSGI server.