### PR TITLE
feat: add blog link to navigation menu

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -51,6 +51,11 @@
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('projects') }}">Projects</a>
                     </li>
+
+                    <li class="nav-item">
+                        <a class="nav-link" href="https://luphonix-blog.onrender.com">Blog</a>
+                    </li>
+
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('contact') }}">Contact</a>
                     </li>


### PR DESCRIPTION
Add a new navigation menu item linking to the external blog hosted on Render. This enhances user accessibility to additional content.